### PR TITLE
Make errors usable across threads

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,7 @@ pub enum Error {
     NullValue,
 
     /// Error when conversion from a string to an Oracle value fails
-    ParseError(Box<error::Error>),
+    ParseError(Box<error::Error + Send + Sync>),
 
     /// Error when conversion from a type to another fails due to out-of-range
     OutOfRange(String),


### PR DESCRIPTION
Will also allow the blanket impl for the `Fail` trait of the [failure](https://github.com/rust-lang-nursery/failure) crate to work.