### PR TITLE
Replace test for Send + Sync with a direct trait assertion

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,8 @@ use std::str;
 use try_from;
 use binding::dpiErrorInfo;
 use binding::dpiContext_getError;
+use AssertSend;
+use AssertSync;
 use Context;
 
 use to_rust_str;
@@ -79,6 +81,9 @@ pub enum Error {
     /// Internal error. When you get this error, please report it with a test case to reproduce it.
     InternalError(String),
 }
+
+impl AssertSend for Error {}
+impl AssertSync for Error {}
 
 /// An error when parsing a string into an Oracle type fails.
 /// This appears only in boxed data associated with [Error::ParseError][].
@@ -340,18 +345,4 @@ macro_rules! chkerr {
             return Err(err);
         }
     }};
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn assert_send<T: Send>() {}
-    fn assert_sync<T: Sync>() {}
-
-    #[test]
-    fn thread_safety() {
-        assert_send::<Error>();
-        assert_sync::<Error>();
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,6 +368,9 @@ enum ContextResult {
 
 unsafe impl Sync for ContextResult {}
 
+trait AssertSend: Send {}
+trait AssertSync: Sync {}
+
 lazy_static! {
     static ref DPI_CONTEXT: ContextResult = {
         let mut ctxt = Context {


### PR DESCRIPTION
This way looks a little nicer and is tested on every compile. I wasn't sure where to put the "Assert" traits, though.