### PR TITLE
Re-add Iterator for `ResultSet<T>` and remove that for `&ResultSet<T>`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ Incompatible changes:
 
 * Remove the associated type `Item` from `RowValue`.
 
+* Iterator for `&ResultSet<T>` was removed and that for `ResultSet<T>`
+  was added again for better ergonomics.
+  Change `for row_result in &result_set {...}` to either `for row_result in result_set {...}` if the `ResultSet` can be consumed
+  or to `for row_result in &mut result_set {...}` otherwise.
+
 ## 0.2.0 (2018-10-02)
 
 Incompatible changes:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ let sql = "select ename, sal, comm from emp where deptno = :1";
 // Select a table with a bind variable.
 println!("---------------|---------------|---------------|");
 let rows = conn.query(sql, &[&30])?;
-for row_result in &rows {
+for row_result in rows {
     let row = row_result?;
     // get a column value by position (0-based)
     let ename: String = row.get(0)?;
@@ -74,7 +74,7 @@ for row_result in &rows {
 // The rows iterator returns Result<(String, i32, Option<i32>)>.
 println!("---------------|---------------|---------------|");
 let rows = conn.query_as::<(String, i32, Option<i32>)>(sql, &[&10])?;
-for row_result in &rows {
+for row_result in rows {
     let (ename, sal, comm) = row_result?;
     println!(" {:14}| {:>10}    | {:>10}    |",
              ename,

--- a/examples/scott-emp.rs
+++ b/examples/scott-emp.rs
@@ -44,7 +44,7 @@ fn main() {
     }
     println!("");
 
-    for row_result in &rows {
+    for row_result in rows {
         let row = row_result.unwrap();
         let empno: i32 = row.get(0).unwrap(); // index by 0-based position
         let ename: String = row.get("ENAME").unwrap(); // index by case-sensitive string

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -39,7 +39,7 @@ fn main() {
     }
     println!("");
 
-    for row_result in &rows {
+    for row_result in rows {
         // print column values
         for (idx, val) in row_result.unwrap().sql_values().iter().enumerate() {
             if idx != 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ let sql = "select ename, sal, comm from emp where deptno = :1";
 // Select a table with a bind variable.
 println!("---------------|---------------|---------------|");
 let rows = conn.query(sql, &[&30])?;
-for row_result in &rows {
+for row_result in rows {
     let row = row_result?;
     // get a column value by position (0-based)
     let ename: String = row.get(0)?;
@@ -88,7 +88,7 @@ for row_result in &rows {
 // The rows iterator returns Result<(String, i32, Option<i32>)>.
 println!("---------------|---------------|---------------|");
 let rows = conn.query_as::<(String, i32, Option<i32>)>(sql, &[&10])?;
-for row_result in &rows {
+for row_result in rows {
     let (ename, sal, comm) = row_result?;
     println!(" {:14}| {:>10}    | {:>10}    |",
              ename,

--- a/src/row.rs
+++ b/src/row.rs
@@ -92,7 +92,7 @@ impl Row {
     /// let conn = Connection::connect("scott", "tiger", "", &[])?;
     /// let mut stmt = conn.prepare("select empno, ename from emp", &[])?;
     ///
-    /// for result in &stmt.query(&[])? {
+    /// for result in stmt.query(&[])? {
     ///     let row = result?;
     ///     // Gets a row as `(i32, String)`.
     ///     let (empno, ename) = row.get_as::<(i32, String)>()?;
@@ -163,7 +163,7 @@ where
     }
 }
 
-impl<'a, 'stmt, T> Iterator for &'a ResultSet<'stmt, T>
+impl<'stmt, T> Iterator for ResultSet<'stmt, T>
 where
     T: RowValue,
 {
@@ -248,7 +248,7 @@ where
 /// let mut stmt = conn.prepare("select * from emp", &[])?;
 ///
 /// // Gets rows as Emp
-/// for result in &stmt.query_as::<Emp>(&[])? {
+/// for result in stmt.query_as::<Emp>(&[])? {
 ///     let emp = result?;
 ///     println!("{},{}", emp.empno, emp.ename);
 /// }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -326,8 +326,8 @@ impl<'conn> Statement<'conn> {
     ///
     /// [Query Methods]: https://github.com/kubo/rust-oracle/blob/master/docs/query-methods.md
     pub fn query_row(&mut self, params: &[&ToSql]) -> Result<Row> {
-        let rows = self.query(params)?;
-        (&rows).next().unwrap_or(Err(Error::NoDataFound))
+        let mut rows = self.query(params)?;
+        rows.next().unwrap_or(Err(Error::NoDataFound))
     }
 
     /// Gets one row from the prepared statement using named bind parameters.
@@ -336,8 +336,8 @@ impl<'conn> Statement<'conn> {
     ///
     /// [Query Methods]: https://github.com/kubo/rust-oracle/blob/master/docs/query-methods.md
     pub fn query_row_named(&mut self, params: &[(&str, &ToSql)]) -> Result<Row> {
-        let rows = self.query_named(params)?;
-        (&rows).next().unwrap_or(Err(Error::NoDataFound))
+        let mut rows = self.query_named(params)?;
+        rows.next().unwrap_or(Err(Error::NoDataFound))
     }
 
     /// Gets one row from the prepared statement as specified type using positoinal bind parameters.
@@ -349,8 +349,8 @@ impl<'conn> Statement<'conn> {
     where
         T: RowValue,
     {
-        let rows = self.query_as::<T>(params)?;
-        (&rows).next().unwrap_or(Err(Error::NoDataFound))
+        let mut rows = self.query_as::<T>(params)?;
+        rows.next().unwrap_or(Err(Error::NoDataFound))
     }
 
     /// Gets one row from the prepared statement as specified type using named bind parameters.
@@ -362,8 +362,8 @@ impl<'conn> Statement<'conn> {
     where
         T: RowValue,
     {
-        let rows = self.query_as_named::<T>(params)?;
-        (&rows).next().unwrap_or(Err(Error::NoDataFound))
+        let mut rows = self.query_as_named::<T>(params)?;
+        rows.next().unwrap_or(Err(Error::NoDataFound))
     }
 
     /// Binds values by position and executes the statement.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -83,7 +83,7 @@ pub fn test_from_sql<T>(
     let mut stmt = conn
         .prepare(&format!("select {} from dual", column_literal), &[])
         .unwrap();
-    let rows = stmt
+    let mut rows = stmt
         .query_as::<T>(&[])
         .expect(format!("error at {}:{}", file, line).as_str());
     assert_eq!(
@@ -93,7 +93,7 @@ pub fn test_from_sql<T>(
         file,
         line
     );
-    let result = (&rows).next().unwrap().unwrap();
+    let result = rows.next().unwrap().unwrap();
     assert_eq!(&result, expected_result, "called by {}:{}", file, line);
 }
 

--- a/tests/statement.rs
+++ b/tests/statement.rs
@@ -448,6 +448,6 @@ fn row_count() {
         .prepare("select * from TestStrings where IntCol >= :1", &[])
         .unwrap();
     assert_eq!(stmt.row_count().unwrap(), 0); // before fetch
-    for _row in &stmt.query(&[&6]).unwrap() {}
+    for _row in stmt.query(&[&6]).unwrap() {}
     assert_eq!(stmt.row_count().unwrap(), 5); // after fetch
 }


### PR DESCRIPTION
There is already an implicit impl for `&mut ResultSet<T>` through a [blanket impl for iterators in std](https://doc.rust-lang.org/std/iter/trait.Iterator.html#impl-Iterator-13), so that can be used if the `ResultSet` should not be consumed. Also, using an immutable borrow for this seemed wrong to me since you obviously couldn't really iterate over the `ResultSet` from multiple threads.