### PR TITLE
Fix #[doc(hide)] attribute

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -851,7 +851,7 @@ impl Connection {
         Ok(())
     }
 
-    #[doc(hide)]
+    #[doc(hidden)]
     pub fn object_type_cache_len(&self) -> usize {
         self.objtype_cache.lock().unwrap().len()
     }


### PR DESCRIPTION
This MR fixes a `#[doc(hide)]` annotation that should have been a `#[doc(hidden)]` one. This attribute is making the repo unable to pass the `cargo clippy` checks with the latest nightly.