### PR TITLE
Add query methods for Statement which take ownership

### DIFF
--- a/src/statement.rs
+++ b/src/statement.rs
@@ -551,6 +551,21 @@ impl<'conn> Statement<'conn> {
         Ok(ResultSet::new(&self.stmt))
     }
 
+    /// Executes the prepared statement and returns a result set containing [`RowValue`]s.
+    ///
+    /// This is the same as [`Statement::query_as()`], but takes ownership of the [`Statement`].
+    ///
+    /// See [Query Methods][].
+    ///
+    /// [Query Methods]: https://github.com/kubo/rust-oracle/blob/master/docs/query-methods.md
+    pub fn into_result_set<'a, T>(mut self, params: &[&dyn ToSql]) -> Result<ResultSet<'a, T>>
+    where
+        T: RowValue,
+    {
+        self.exec(params, true, "into_result_set")?;
+        Ok(ResultSet::from_stmt(self.stmt))
+    }
+
     /// Executes the prepared statement using named parameters and returns a result set containing [`RowValue`]s.
     ///
     /// See [Query Methods][].
@@ -565,6 +580,24 @@ impl<'conn> Statement<'conn> {
     {
         self.exec_named(params, true, "query_as_named")?;
         Ok(ResultSet::new(&self.stmt))
+    }
+
+    /// Executes the prepared statement using named parameters and returns a result set containing [`RowValue`]s.
+    ///
+    /// This is the same as [`Statement::query_as_named()`], but takes ownership of the [`Statement`].
+    ///
+    /// See [Query Methods][].
+    ///
+    /// [Query Methods]: https://github.com/kubo/rust-oracle/blob/master/docs/query-methods.md
+    pub fn into_result_set_named<'a, T>(
+        mut self,
+        params: &[(&str, &dyn ToSql)],
+    ) -> Result<ResultSet<'a, T>>
+    where
+        T: RowValue,
+    {
+        self.exec_named(params, true, "into_result_set_named")?;
+        Ok(ResultSet::from_stmt(self.stmt))
     }
 
     /// Gets one row from the prepared statement using positoinal bind parameters.


### PR DESCRIPTION
Hi,

basically as the title and commit message says.
It mimics the interface of `Connection::query_*()`, which take ownership of the statement instead of borrowing it.
I hope the method names are okay, but I'll happily rename them if there are any better suggestions.

This can be used if `StatementBuilder` needs to be used, without having to store both `Statement` and the `ResultSet` in a struct together (which is quite painful in Rust to do).

Thanks!