### PR TITLE
document minimum rustc version & add to test matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,30 @@
 name: Run tests
 on: [push, pull_request]
 jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [1.54.0, stable]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: ${{ matrix.features }}
+
+
   tests:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is an [Oracle database][] driver for [Rust][] based on [ODPI-C][].
 See [ChangeLog.md](https://github.com/kubo/rust-oracle/blob/master/ChangeLog.md).
 
 ## Build-time Requirements
-
+* Rust 1.54.0 or newer
 * C compiler. See `Compile-time Requirements` in [this document](https://github.com/alexcrichton/cc-rs#compile-time-requirements).
 
 ## Run-time Requirements


### PR DESCRIPTION
with this consumers get a guarantee for which rustc versions will work.

previously (up to at least version 0.5.1) it was possible to build this library with rustc 1.42.0, now it needs at least 1.54.0 due to this line:
https://github.com/kubo/rust-oracle/blob/88b45ae4bccd9f48e820e1f7502bd0aee21be846/oracle_procmacro/src/lib.rs#L31

see also #57

see the commit messages for further details.