### PR TITLE
Add a way to check if the Oracle Client libs are present at runtime

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,9 +537,17 @@ fn to_rust_slice<'a>(ptr: *const c_char, len: u32) -> &'a [u8] {
     }
 }
 
-/// Tries to get the Oracle Client context, returning the error if unable to
-pub fn can_get_context() -> Result<()> {
-    Context::get().map(|_| ())
+/// Tries to get the Oracle Client context, returning the false if unable to
+pub fn can_get_context() -> bool {
+    match Context::get() {
+        Ok(_) => {
+            false
+        },
+        Err(e) => match e {
+            Error::DpiError(e) => e.action() == "load library",
+            _ => false
+        },
+    }
 }
 
 mod private {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,6 +537,11 @@ fn to_rust_slice<'a>(ptr: *const c_char, len: u32) -> &'a [u8] {
     }
 }
 
+/// Tries to get the Oracle Client context, returning the error if unable to
+pub fn can_get_context() -> Result<()> {
+    Context::get().map(|_| ())
+}
+
 mod private {
     use std::os::raw::c_void;
 


### PR DESCRIPTION
I'd like to check if the Oracle Client libs are present. As a workaround I was creating a dummy connection and checking if it errored, but it's not optimal.