### PR TITLE
fix: correct struct name in `impl fmt::Debug for LobLocator`

### DIFF
--- a/src/sql_type/lob.rs
+++ b/src/sql_type/lob.rs
@@ -332,7 +332,11 @@ impl Clone for LobLocator {
 
 impl fmt::Debug for LobLocator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Lob {{ handle: {:?}, pos: {} }} ", self.handle, self.pos)
+        write!(
+            f,
+            "LobLocator {{ handle: {:?}, pos: {} }} ",
+            self.handle, self.pos
+        )
     }
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/kubo/rust-oracle/pull/96#issuecomment-2708861672

Automated reformatting courtesy of `rustfmt`.